### PR TITLE
Add egg stage with hatching logic

### DIFF
--- a/src/pet_model.py
+++ b/src/pet_model.py
@@ -9,6 +9,7 @@ from typing import Dict
 class Stage(Enum):
     """Life stages for the pet."""
 
+    EGG = "Egg"
     BABY = "Baby"
     CHILD = "Child"
     TEEN = "Teen"
@@ -21,7 +22,7 @@ class Pet:
     """Represents a virtual pet and its state."""
 
     age_minutes: int = 0
-    stage: Stage = Stage.BABY
+    stage: Stage = Stage.EGG
     hunger_hearts: int = 4
     happiness_hearts: int = 4
     discipline_percent: int = 0
@@ -101,7 +102,9 @@ class Pet:
 
     def _maybe_evolve(self) -> None:
         """Handle stage evolution based on age."""
-        if self.stage == Stage.BABY and self.age_minutes >= 65:
+        if self.stage == Stage.EGG and self.age_minutes >= 5:
+            self.stage = Stage.BABY
+        elif self.stage == Stage.BABY and self.age_minutes >= 65:
             self.stage = Stage.CHILD
         elif self.stage == Stage.CHILD and self.age_minutes >= 3 * 24 * 60:
             self.stage = Stage.TEEN
@@ -127,7 +130,7 @@ class Pet:
         """Create a Pet from saved data."""
         pet = cls()
         pet.age_minutes = int(data.get("age_minutes", 0))
-        pet.stage = Stage(data.get("stage", Stage.BABY.value))
+        pet.stage = Stage(data.get("stage", Stage.EGG.value))
         pet.hunger_hearts = int(data.get("hunger_hearts", 4))
         pet.happiness_hearts = int(data.get("happiness_hearts", 4))
         pet.discipline_percent = int(data.get("discipline_percent", 0))

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3,7 +3,7 @@
 import os
 import unittest
 
-from src.pet_model import Pet
+from src.pet_model import Pet, Stage
 from src.persistence import load_pet, save_pet
 
 
@@ -25,10 +25,12 @@ class TestPersistence(unittest.TestCase):
         save_pet(pet, self.path)
         loaded = load_pet(self.path)
         self.assertEqual(loaded.hunger_hearts, 2)
+        self.assertEqual(loaded.stage, pet.stage)
 
     def test_load_new_when_missing(self) -> None:
         pet = load_pet(self.path)
         self.assertIsInstance(pet, Pet)
+        self.assertEqual(pet.stage, Stage.EGG)
 
 
 if __name__ == "__main__":

--- a/tests/test_pet_model.py
+++ b/tests/test_pet_model.py
@@ -8,6 +8,15 @@ from src.pet_model import Pet, Stage
 class TestPetModel(unittest.TestCase):
     """Test cases for the Pet class."""
 
+    def test_initial_stage(self) -> None:
+        pet = Pet()
+        self.assertEqual(pet.stage, Stage.EGG)
+
+    def test_hatch_after_five_minutes(self) -> None:
+        pet = Pet()
+        pet.tick(5)
+        self.assertEqual(pet.stage, Stage.BABY)
+
     def test_feed_meal(self) -> None:
         pet = Pet()
         pet.hunger_hearts = 3


### PR DESCRIPTION
## Summary
- add `EGG` to `Stage`
- hatch from `EGG` to `BABY` after 5 minutes
- default new pets to `EGG`
- persist new stage in saved data
- expand tests for new stage and persistence

## Testing
- `python -m unittest discover -v`