### PR TITLE
Add sickness checks and multi-dose medicine

### DIFF
--- a/src/pet_model.py
+++ b/src/pet_model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict
+import random
 
 
 class Stage(Enum):
@@ -33,6 +34,7 @@ class Pet:
     minutes_since_last_hunger: int = field(default=0, init=False)
     minutes_since_last_happy: int = field(default=0, init=False)
     minutes_since_last_poop: int = field(default=0, init=False)
+    medicine_doses_left: int = field(default=0, init=False)
 
     def tick(self, minutes: int = 1) -> None:
         """Advance time for the pet by the given number of minutes."""
@@ -60,6 +62,10 @@ class Pet:
                 self.poop_count += 1
                 self.minutes_since_last_poop = 0
 
+            if (self.poop_count >= 3 or self.weight > 20) and not self.is_sick:
+                self.is_sick = True
+                self.medicine_doses_left = random.choice([1, 2])
+
             self._maybe_evolve()
 
     def feed(self, food_type: str) -> bool:
@@ -74,8 +80,9 @@ class Pet:
             if self.happiness_hearts < 4:
                 self.happiness_hearts += 1
             self.weight += 2
-            if self.weight > 20:
+            if self.weight > 20 and not self.is_sick:
                 self.is_sick = True
+                self.medicine_doses_left = random.choice([1, 2])
             return True
         return False
 
@@ -93,7 +100,10 @@ class Pet:
     def give_medicine(self) -> None:
         """Cure the pet if it is sick."""
         if self.is_sick:
-            self.is_sick = False
+            if self.medicine_doses_left > 0:
+                self.medicine_doses_left -= 1
+            if self.medicine_doses_left <= 0:
+                self.is_sick = False
 
     def discipline(self) -> None:
         """Discipline the pet."""

--- a/tests/test_pet_model.py
+++ b/tests/test_pet_model.py
@@ -1,6 +1,7 @@
 """Tests for Pet model."""
 
 import unittest
+from unittest.mock import patch
 
 from src.pet_model import Pet, Stage
 
@@ -33,6 +34,38 @@ class TestPetModel(unittest.TestCase):
         pet = Pet()
         pet.tick(65)
         self.assertEqual(pet.stage, Stage.CHILD)
+
+    def test_tick_sickness_from_poop(self) -> None:
+        pet = Pet()
+        pet.poop_count = 3
+        with patch('random.choice', return_value=1):
+            pet.tick()
+        self.assertTrue(pet.is_sick)
+        self.assertEqual(pet.medicine_doses_left, 1)
+
+    def test_tick_sickness_from_weight(self) -> None:
+        pet = Pet()
+        pet.weight = 25
+        with patch('random.choice', return_value=2):
+            pet.tick()
+        self.assertTrue(pet.is_sick)
+        self.assertEqual(pet.medicine_doses_left, 2)
+
+    def test_medicine_two_doses(self) -> None:
+        pet = Pet()
+        pet.is_sick = True
+        pet.medicine_doses_left = 2
+        pet.give_medicine()
+        self.assertTrue(pet.is_sick)
+        pet.give_medicine()
+        self.assertFalse(pet.is_sick)
+
+    def test_medicine_single_dose(self) -> None:
+        pet = Pet()
+        pet.is_sick = True
+        pet.medicine_doses_left = 1
+        pet.give_medicine()
+        self.assertFalse(pet.is_sick)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- trigger illness in `Pet.tick` when poop piles or heavy weight are present
- randomize if one or two medicine doses are required
- update `give_medicine` to handle multi-dose cures
- expand tests for new sickness and medicine logic

## Testing
- `python3 -m unittest -v`