### PR TITLE
Add Tauri app prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # WindowGotchi
 
-A simple desktop virtual pet inspired by Tamagotchi. The prototype is written in
-Python using Tkinter for the UI.
+A simple desktop virtual pet inspired by Tamagotchi. The prototype is written in Python using Tkinter for the UI.
 
 ## Setup
 
@@ -20,3 +19,24 @@ python main.py
 - `main.py`: Main entry point
 - `src/`: Source code modules
 - `tests/`: Test files
+- `tauri-app/`: Tauri-based Rust + web prototype
+
+## Building the Tauri App
+
+The `tauri-app/` folder contains an experimental Tauri version of WindowGotchi.
+To build it you need a recent Node.js and Rust toolchain installed. Then run:
+
+```bash
+cd tauri-app
+npm install
+npm run build        # compile TypeScript
+npm run tauri-build  # build the desktop app
+```
+
+During development you can launch it with:
+
+```bash
+npm run tauri
+```
+
+This will start the Tauri dev environment and open the application window.

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "windowgotchi-tauri",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "tsc",
+    "tauri": "tauri dev",
+    "tauri-build": "tauri build"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "@tauri-apps/cli": "^1.2.0"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^1.2.0"
+  }
+}

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tauri-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["api-all"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[build-dependencies]
+
+[features]
+default = ["custom-protocol"]
+
+[tauri]

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -1,0 +1,54 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use tauri::State;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct PetState {
+    age_minutes: u32,
+    stage: String,
+    hunger_hearts: u8,
+    happiness_hearts: u8,
+    discipline_percent: u8,
+    weight: u8,
+    care_mistakes: u8,
+    is_sick: bool,
+    poop_count: u8,
+}
+
+impl Default for PetState {
+    fn default() -> Self {
+        Self {
+            age_minutes: 0,
+            stage: "Baby".into(),
+            hunger_hearts: 4,
+            happiness_hearts: 4,
+            discipline_percent: 0,
+            weight: 5,
+            care_mistakes: 0,
+            is_sick: false,
+            poop_count: 0,
+        }
+    }
+}
+
+struct AppState(Mutex<PetState>);
+
+#[tauri::command]
+fn get_state(state: State<AppState>) -> PetState {
+    state.0.lock().unwrap().clone()
+}
+
+#[tauri::command]
+fn set_state(new_state: PetState, state: State<AppState>) {
+    *state.0.lock().unwrap() = new_state;
+}
+
+fn main() {
+    tauri::Builder::default()
+        .manage(AppState(Mutex::new(PetState::default())))
+        .invoke_handler(tauri::generate_handler![get_state, set_state])
+        .run(tauri::generate_context!())
+        .expect("failed to run tauri application");
+}

--- a/tauri-app/src/index.html
+++ b/tauri-app/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>WindowGotchi Tauri</title>
+  <script type="module" src="index.js"></script>
+</head>
+<body>
+  <h1>WindowGotchi</h1>
+  <pre id="status"></pre>
+  <button id="feed">Feed Snack</button>
+</body>
+</html>

--- a/tauri-app/src/index.ts
+++ b/tauri-app/src/index.ts
@@ -1,0 +1,29 @@
+import { invoke } from "@tauri-apps/api/tauri";
+import { Pet, PetState } from "./pet";
+
+const statusEl = document.getElementById("status") as HTMLElement;
+const feedBtn = document.getElementById("feed") as HTMLButtonElement;
+
+let pet = new Pet();
+
+async function load() {
+  const state = (await invoke("get_state")) as PetState;
+  Object.assign(pet, state);
+  render();
+}
+
+async function save() {
+  await invoke("set_state", { newState: pet });
+}
+
+function render() {
+  statusEl.textContent = JSON.stringify(pet, null, 2);
+}
+
+feedBtn.addEventListener("click", async () => {
+  pet.feed("snack");
+  render();
+  await save();
+});
+
+load();

--- a/tauri-app/src/pet.ts
+++ b/tauri-app/src/pet.ts
@@ -1,0 +1,106 @@
+export enum Stage {
+  BABY = "Baby",
+  CHILD = "Child",
+  TEEN = "Teen",
+  ADULT = "Adult",
+  DEAD = "Dead",
+}
+
+export interface PetState {
+  age_minutes: number;
+  stage: Stage;
+  hunger_hearts: number;
+  happiness_hearts: number;
+  discipline_percent: number;
+  weight: number;
+  care_mistakes: number;
+  is_sick: boolean;
+  poop_count: number;
+}
+
+export class Pet implements PetState {
+  age_minutes = 0;
+  stage = Stage.BABY;
+  hunger_hearts = 4;
+  happiness_hearts = 4;
+  discipline_percent = 0;
+  weight = 5;
+  care_mistakes = 0;
+  is_sick = false;
+  poop_count = 0;
+
+  private minutes_since_last_hunger = 0;
+  private minutes_since_last_happy = 0;
+  private minutes_since_last_poop = 0;
+
+  tick(minutes = 1): void {
+    for (let i = 0; i < minutes; i++) {
+      this.age_minutes++;
+      this.minutes_since_last_hunger++;
+      this.minutes_since_last_happy++;
+      this.minutes_since_last_poop++;
+
+      if (this.minutes_since_last_hunger >= 60) {
+        if (this.hunger_hearts > 0) this.hunger_hearts--;
+        this.minutes_since_last_hunger = 0;
+        if (this.hunger_hearts === 0) this.care_mistakes++;
+      }
+
+      if (this.minutes_since_last_happy >= 70) {
+        if (this.happiness_hearts > 0) this.happiness_hearts--;
+        this.minutes_since_last_happy = 0;
+        if (this.happiness_hearts === 0) this.care_mistakes++;
+      }
+
+      if (this.minutes_since_last_poop >= 180) {
+        this.poop_count++;
+        this.minutes_since_last_poop = 0;
+      }
+
+      this.maybeEvolve();
+    }
+  }
+
+  feed(foodType: "meal" | "snack"): boolean {
+    if (foodType === "meal") {
+      if (this.hunger_hearts >= 4) return false;
+      this.hunger_hearts++;
+      this.weight++;
+      return true;
+    }
+    if (foodType === "snack") {
+      if (this.happiness_hearts < 4) this.happiness_hearts++;
+      this.weight += 2;
+      if (this.weight > 20) this.is_sick = true;
+      return true;
+    }
+    return false;
+  }
+
+  playGame(roundsWon: number): void {
+    if (roundsWon >= 3 && this.happiness_hearts < 4) this.happiness_hearts++;
+    if (this.weight > 1) this.weight--;
+  }
+
+  cleanPoop(): void {
+    this.poop_count = 0;
+  }
+
+  giveMedicine(): void {
+    if (this.is_sick) this.is_sick = false;
+  }
+
+  discipline(): void {
+    this.discipline_percent = Math.min(100, this.discipline_percent + 25);
+  }
+
+  private maybeEvolve(): void {
+    if (this.stage === Stage.BABY && this.age_minutes >= 65) {
+      this.stage = Stage.CHILD;
+    } else if (this.stage === Stage.CHILD && this.age_minutes >= 3 * 24 * 60) {
+      this.stage = Stage.TEEN;
+    } else if (this.stage === Stage.TEEN && this.age_minutes >= 6 * 24 * 60) {
+      this.stage = Stage.ADULT;
+    }
+  }
+}

--- a/tauri-app/tauri.conf.json
+++ b/tauri-app/tauri.conf.json
@@ -1,0 +1,20 @@
+{
+  "build": {
+    "beforeBuildCommand": "",
+    "beforeDevCommand": "",
+    "devPath": "../tauri-app/src",
+    "distDir": "../tauri-app/src"
+  },
+  "package": {
+    "productName": "WindowGotchi",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "active": false
+    },
+    "allowlist": {
+      "all": true
+    }
+  }
+}

--- a/tauri-app/tsconfig.json
+++ b/tauri-app/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es6",
+    "outDir": "./src",
+    "rootDir": "./src",
+    "strict": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `tauri-app/` folder with a minimal Tauri setup
- port pet logic into `pet.ts`
- expose state via Rust commands
- document how to build the Tauri prototype

## Testing
- `python -m unittest discover -v`