### PR TITLE
Fix missing random import

### DIFF
--- a/src/pet_model.py
+++ b/src/pet_model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict
+import random
 
 # Evolution and lifespan thresholds (in minutes)
 CHILD_AGE_MINUTES = 65


### PR DESCRIPTION
## Summary
- import `random` at the top of `pet_model.py`

## Testing
- `python -m unittest discover -v` *(fails: test_hatch_after_five_minutes, test_tick_evolution, test_tick_sickness_from_poop, test_tick_sickness_from_weight, and test_notify_and_tray)*