### PR TITLE
Enable system tray icon and fix unit tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ class WindowGotchiApp:
         self.root = root
         self.pet: Pet = load_pet()
         self.nm = NotificationManager()
+        self.nm.start_tray_icon()
         self.am = AudioManager()
         self.status = tk.StringVar()
         tk.Label(root, textvariable=self.status, font=("Courier", 12)).pack(pady=10)

--- a/src/pet_model.py
+++ b/src/pet_model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict
+import random
 
 # Evolution and lifespan thresholds (in minutes)
 CHILD_AGE_MINUTES = 65
@@ -44,6 +45,7 @@ class Pet:
     weight: int = 5
     care_mistakes: int = 0
     is_sick: bool = False
+    medicine_doses_left: int = 0
     poop_count: int = 0
 
     # discipline / misbehavior tracking
@@ -105,6 +107,9 @@ class Pet:
                     self.misbehaving = False
                     self.minutes_misbehaving = 0
 
+            if not self.is_sick and (self.poop_count >= 3 or self.weight >= 25):
+                self.is_sick = True
+                self.medicine_doses_left = random.choice([1, 2])
 
             self._maybe_evolve()
 
@@ -159,8 +164,9 @@ class Pet:
     def _maybe_evolve(self) -> None:
 
         """Handle stage evolution and death based on age."""
-        if self.stage == Stage.BABY and self.age_minutes >= CHILD_AGE_MINUTES:
-
+        if self.stage == Stage.EGG and self.age_minutes >= HATCH_TIME_MINUTES:
+            self.stage = Stage.BABY
+        elif self.stage == Stage.BABY and self.age_minutes >= CHILD_AGE_MINUTES:
             self.stage = Stage.CHILD
         elif self.stage == Stage.CHILD and self.age_minutes >= TEEN_AGE_MINUTES:
             self.stage = Stage.TEEN
@@ -184,6 +190,7 @@ class Pet:
             "weight": self.weight,
             "care_mistakes": self.care_mistakes,
             "is_sick": self.is_sick,
+            "medicine_doses_left": self.medicine_doses_left,
             "poop_count": self.poop_count,
         }
 
@@ -199,5 +206,6 @@ class Pet:
         pet.weight = int(data.get("weight", 5))
         pet.care_mistakes = int(data.get("care_mistakes", 0))
         pet.is_sick = bool(data.get("is_sick", False))
+        pet.medicine_doses_left = int(data.get("medicine_doses_left", 0))
         pet.poop_count = int(data.get("poop_count", 0))
         return pet

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,6 +1,7 @@
 """Tests for managers."""
 
 import unittest
+from unittest.mock import patch
 
 
 from src.audio_manager import AudioManager

--- a/tests/test_pet_model.py
+++ b/tests/test_pet_model.py
@@ -1,6 +1,7 @@
 """Tests for Pet model."""
 
 import unittest
+from unittest.mock import patch
 
 
 from src.pet_model import (


### PR DESCRIPTION
## Summary
- start system tray icon when launching the GUI
- implement pet hatching and sickness features
- store medicine dose count in persistence
- fix missing imports in tests

## Testing
- `python -m unittest discover -v`