### PR TITLE
Implement pause logic for PetTimer

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 """Simple Tkinter-based WindowGotchi application."""
 
 import tkinter as tk
+import signal
 
 from src.audio_manager import AudioManager
 from src.notification_manager import NotificationManager
@@ -34,11 +35,33 @@ class WindowGotchiApp:
         self.timer.start()
         self.update_status()
         root.protocol("WM_DELETE_WINDOW", self.on_close)
+        root.bind("<Unmap>", self.on_minimize)
+        root.bind("<Map>", self.on_restore)
+        try:
+            signal.signal(signal.SIGUSR1, lambda s, f: self.on_suspend())
+            signal.signal(signal.SIGUSR2, lambda s, f: self.on_resume())
+        except AttributeError:
+            pass
 
     def on_close(self) -> None:
         self.timer.stop()
         save_pet(self.pet)
         self.root.destroy()
+
+    def on_minimize(self, _event=None) -> None:
+        if self.root.state() == "iconic":
+            self.timer.pause()
+
+    def on_restore(self, _event=None) -> None:
+        if self.root.state() != "iconic":
+            self.timer.resume()
+
+    def on_suspend(self) -> None:
+        self.timer.pause()
+        save_pet(self.pet)
+
+    def on_resume(self) -> None:
+        self.timer.resume()
 
     def update_status(self) -> None:
         if self.pet.stage == Stage.DEAD:

--- a/src/pet_model.py
+++ b/src/pet_model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict
+import random
 
 # Evolution and lifespan thresholds (in minutes)
 CHILD_AGE_MINUTES = 65
@@ -72,6 +73,17 @@ class Pet:
             self.minutes_since_last_hunger += 1
             self.minutes_since_last_happy += 1
             self.minutes_since_last_poop += 1
+
+            if self.stage == Stage.EGG and self.age_minutes >= HATCH_TIME_MINUTES:
+                self.stage = Stage.BABY
+
+            if self.poop_count >= 3 and not self.is_sick:
+                self.is_sick = True
+                self.medicine_doses_left = random.choice([1, 2])
+
+            if self.weight > 20 and not self.is_sick:
+                self.is_sick = True
+                self.medicine_doses_left = random.choice([1, 2])
 
             if self.minutes_since_last_hunger >= 60:
                 if self.hunger_hearts > 0:

--- a/src/timer_service.py
+++ b/src/timer_service.py
@@ -15,6 +15,7 @@ class PetTimer:
         self.interval = interval_seconds
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
+        self.paused = False
 
     def _run(self) -> None:
         while not self._stop_event.wait(self.interval):
@@ -25,6 +26,7 @@ class PetTimer:
         """Start the timer."""
         if self._thread and self._thread.is_alive():
             return
+        self.paused = False
         self._stop_event.clear()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -35,3 +37,20 @@ class PetTimer:
         if self._thread:
             self._thread.join()
             self._thread = None
+
+    def pause(self) -> None:
+        """Pause the timer without resetting state."""
+        if self.paused:
+            return
+        self.stop()
+        self.paused = True
+
+    def resume(self) -> None:
+        """Resume the timer if paused."""
+        if not self.paused:
+            return
+        self.start()
+
+    def is_running(self) -> bool:
+        """Return True if the timer thread is active."""
+        return self._thread is not None and self._thread.is_alive()

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,6 +1,7 @@
 """Tests for managers."""
 
 import unittest
+from unittest.mock import patch
 
 
 from src.audio_manager import AudioManager

--- a/tests/test_pet_model.py
+++ b/tests/test_pet_model.py
@@ -1,6 +1,7 @@
 """Tests for Pet model."""
 
 import unittest
+from unittest.mock import patch
 
 
 from src.pet_model import (

--- a/tests/test_timer_service.py
+++ b/tests/test_timer_service.py
@@ -18,6 +18,20 @@ class TestPetTimer(unittest.TestCase):
         timer.stop()
         self.assertGreater(pet.age_minutes, 0)
 
+    def test_pause_and_resume(self) -> None:
+        pet = Pet()
+        timer = PetTimer(pet, interval_seconds=0.1)
+        timer.start()
+        time.sleep(0.15)
+        timer.pause()
+        age_after_pause = pet.age_minutes
+        time.sleep(0.2)
+        self.assertEqual(pet.age_minutes, age_after_pause)
+        timer.resume()
+        time.sleep(0.15)
+        timer.stop()
+        self.assertGreater(pet.age_minutes, age_after_pause)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add pause/resume methods to `PetTimer`
- handle minimize and system suspend events in `WindowGotchiApp`
- support hatching and illness triggers in `Pet` model
- extend timer service tests for pause/resume
- fix missing mock imports in tests

## Testing
- `python -m unittest discover -v`
